### PR TITLE
Update de.yml

### DIFF
--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -431,9 +431,9 @@ de:
         end_insertion: Ende der Einfügung
         end_deletion: Ende des Löschvorgangs
         fixed_version: Version
-        parent: Übergeordnete Aufgabe
-        parent_issue: Übergeordnete Aufgabe
-        parent_work_package: Übergeordnete Aufgabe
+        parent: Hauptaufgabe
+        parent_issue: Hauptaufgabe
+        parent_work_package: Hauptaufgabe
         priority: Priorität
         progress: Fortschritt (%)
         responsible: Verantwortlicher


### PR DESCRIPTION
The German expression **übergeordnete Aufgabe** is correct but very long and takes a lot of space as a column in the project overview. That's why I suggest **Hauptaufgabe** which is shorter and so you have more space for other columns in the overview. Maybe someone knows an even shorter word as the column will only show the ID.